### PR TITLE
Use Qt directives for more generic installation

### DIFF
--- a/declarative/declarative.pro
+++ b/declarative/declarative.pro
@@ -4,8 +4,12 @@ QT += declarative
 
 PKGCONFIG = grilo-0.2
 
-DESTDIR = org/nemomobile/grilo
+EXAMPLE = ../example/*
+
+OTHER_FILES += $${EXAMPLE}
+
 TARGET = qmlgriloplugin
+PLUGIN_IMPORT_PATH = org/nemomobile/grilo
 
 SOURCES += griloplugin.cpp grilomodel.cpp griloregistry.cpp grilomedia.cpp grilodatasource.cpp \
            grilobrowse.cpp grilosearch.cpp griloquery.cpp grilomultisearch.cpp
@@ -13,8 +17,8 @@ SOURCES += griloplugin.cpp grilomodel.cpp griloregistry.cpp grilomedia.cpp grilo
 HEADERS += griloplugin.h grilomodel.h griloregistry.h grilomedia.h grilodatasource.h \
            grilobrowse.h grilosearch.h griloquery.h grilomultisearch.h
 
-target.path = /usr/lib/qt4/imports/org/nemomobile/grilo/
+target.path = $$[QT_INSTALL_IMPORTS]/$$PLUGIN_IMPORT_PATH
 qml.files = qmldir
-qml.path = /usr/lib/qt4/imports/org/nemomobile/grilo/
+qml.path = $$[QT_INSTALL_IMPORTS]/$$$$PLUGIN_IMPORT_PATH
 
 INSTALLS += target qml


### PR DESCRIPTION
Use Qt directives for more generic installation.
Make examples visible in QtCreator project.
