### PR TITLE
Prevent QML from deleting media objects when garbage collected.

### DIFF
--- a/declarative/grilomodel.cpp
+++ b/declarative/grilomodel.cpp
@@ -24,6 +24,8 @@
 #include "grilomedia.h"
 #include "grilodatasource.h"
 
+#include <QQmlEngine>
+
 GriloModel::GriloModel(QObject *parent) :
   QAbstractListModel(parent),
   m_source(0) {
@@ -94,7 +96,10 @@ QObject *GriloModel::get(int index) const {
     return 0;
   }
 
-  return m_source->media()->at(index);
+  QObject *media = m_source->media()->at(index);
+  QQmlEngine::setObjectOwnership(media, QQmlEngine::CppOwnership);
+
+  return media;
 }
 
 int GriloModel::count() const {


### PR DESCRIPTION
QObjects returned from invokable methods are assumed to be owned by the
javascript engine unless otherwise specified and will be deleted during
garbage collection.  Mark media objects as having cpp ownership so this
doesn't happen.
