### PR TITLE
[model] countChanged signal emitted immediately from rows[Inserted|Removed] ones

### DIFF
--- a/declarative/grilodatasource.cpp
+++ b/declarative/grilodatasource.cpp
@@ -73,8 +73,6 @@ void GriloDataSource::prefill(GriloModel *model) {
 
   model->beginInsertRows(QModelIndex(), 0, m_media.size() - 1);
   model->endInsertRows();
-
-  emit model->countChanged();
 }
 
 void GriloDataSource::addMedia(GrlMedia *media) {
@@ -129,7 +127,6 @@ void GriloDataSource::addMedia(GrlMedia *media) {
 
   foreach (GriloModel *model, m_models) {
     model->endInsertRows();
-    emit model->countChanged();
   }
 
 }
@@ -164,7 +161,6 @@ void GriloDataSource::removeMedia(GrlMedia *media) {
 
   foreach (GriloModel *model, m_models) {
     model->endRemoveRows();
-    emit model->countChanged();
   }
 }
 
@@ -185,7 +181,6 @@ void GriloDataSource::clearMedia() {
 
   foreach (GriloModel *model, m_models) {
     model->endRemoveRows();
-    emit model->countChanged();
   }
 }
 
@@ -359,7 +354,6 @@ void GriloDataSource::grilo_source_result_cb(GrlSource *source, guint op_id,
       }
       foreach (GriloModel *model, that->m_models) {
         model->endRemoveRows();
-        emit model->countChanged();
       }
     }
   }

--- a/declarative/grilomodel.cpp
+++ b/declarative/grilomodel.cpp
@@ -34,6 +34,11 @@ GriloModel::GriloModel(QObject *parent) :
   roles[MediaRole] = "media";
 
   setRoleNames(roles);
+
+  QObject::connect(this, SIGNAL(rowsInserted(const QModelIndex&, int, int)),
+                   this, SIGNAL(countChanged()));
+  QObject::connect(this, SIGNAL(rowsRemoved(const QModelIndex&, int, int)),
+                   this, SIGNAL(countChanged()));
 }
 
 GriloModel::~GriloModel() {


### PR DESCRIPTION
Having the emission of the signals done manually in the datasource is
error prone. Let's just chain the emission of the countChanged signal
to the emission of the rowsInserted and rowsRemoved signals from the
own model object.