### PR TITLE
[media] Added get method to request arbitrary key

### DIFF
--- a/declarative/grilomedia.h
+++ b/declarative/grilomedia.h
@@ -27,6 +27,7 @@
 #include <QObject>
 #include <grilo.h>
 #include <QUrl>
+#include <QVariant>
 
 class GriloMedia : public QObject {
   Q_OBJECT
@@ -67,9 +68,12 @@ public:
   GrlMedia *media();
   void setMedia(GrlMedia *media);
 
+  Q_INVOKABLE QVariant get(const QString& keyId) const;
   Q_INVOKABLE QString serialize();
 
 private:
+  QVariant convertValue(const GValue *value) const;
+
   GrlMedia *m_media;
 };
 


### PR DESCRIPTION
New "get" method added to GriloMedia.

Now, it is possible to request the value stored in
an arbitrary key through its name.

The key can be a standard one from Grilo core or
another one dynamically added to the registry by a
plugin or application.
